### PR TITLE
fix: Append hash to generated file names to avoid conflicts on case-insensitive filesystems

### DIFF
--- a/src/fs/dir.rs
+++ b/src/fs/dir.rs
@@ -57,7 +57,7 @@ pub fn dump_dir(dump_dir: &str, output_strings: Vec<String>) {
             .replace([' ', '/'], "_") // This is to handle the "tests/itest" in ARGS
             .replace(&['<', '>', ':', '"', '/', '\\', '|', '?', '*'][..], "_"); // Sanitize for Windows
 
-        let file_path = dump_path.join(format!("ptest_{}_{:x}.toml", args, hash(&args)));
+        let file_path = dump_path.join(format!("ptest_{:x}.toml", hash(&args)));
         let mut file = File::create(&file_path)
             .unwrap_or_else(|_| panic!("Failed to create file at {:?}", file_path));
         file.write_all(content.as_bytes())

--- a/src/fs/dir.rs
+++ b/src/fs/dir.rs
@@ -1,4 +1,6 @@
+use std::collections::hash_map::DefaultHasher;
 use std::fs::File;
+use std::hash::{Hash, Hasher};
 use std::io::Write;
 use std::path::Path;
 
@@ -55,10 +57,16 @@ pub fn dump_dir(dump_dir: &str, output_strings: Vec<String>) {
             .replace([' ', '/'], "_") // This is to handle the "tests/itest" in ARGS
             .replace(&['<', '>', ':', '"', '/', '\\', '|', '?', '*'][..], "_"); // Sanitize for Windows
 
-        let file_path = dump_path.join(format!("ptest_{}.toml", args));
+        let file_path = dump_path.join(format!("ptest_{}_{:x}.toml", args, hash(&args)));
         let mut file = File::create(&file_path)
             .unwrap_or_else(|_| panic!("Failed to create file at {:?}", file_path));
         file.write_all(content.as_bytes())
             .expect("Failed to write to file");
     }
+}
+
+fn hash<T: Hash>(t: &T) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    t.hash(&mut hasher);
+    hasher.finish()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,7 @@ fn main() -> std::io::Result<()> {
     // NOTE: for some reason this is always true for u8, but I don't trust it
     } else if let Some(stdin) = matches.get_one::<u8>("stdin") {
         // If --stdin set
+        #[allow(clippy::suspicious_else_formatting)]
         if stdin > &0 {
             parse = crate::parser::parse(std::io::stdin().lock());
         }


### PR DESCRIPTION
The default filesystem on MacOS is case-insensitive but has case preserving file names.  If the test generation has arguments that just differ in case a case-insensitive file name conflict may happen.  This fix appends a hash to the generated file name to make them unique.

Fixes issue https://github.com/eza-community/powertest/issues/10