### PR TITLE
feat: add an eol and eof

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -83,7 +83,7 @@ fn main() -> std::io::Result<()> {
         .iter()
         .map(|subset| {
             format!(
-                "bin.name = \"{}\"\nargs = \"{} {}\"",
+                "bin.name = \"{}\"\nargs = \"{} {}\"\n",
                 &config.binary.as_ref().unwrap(),
                 &config.args.as_ref().unwrap(),
                 subset.join(" ")


### PR DESCRIPTION
The reason of this change is due to [posix definition of a line](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_206)